### PR TITLE
fix: prevent unnecessary retry when auth code already captured via CDP

### DIFF
--- a/src/auth/GMAuth.ts
+++ b/src/auth/GMAuth.ts
@@ -2548,7 +2548,13 @@ export class GMAuth {
       postSubmitTitle = await page.title();
 
       // Check if we're still on the sign-in page (credential submission failed)
-      if (postSubmitTitle.toLowerCase().includes("sign in")) {
+      // BUT FIRST: Check if we already captured the auth code via CDP - if so, auth succeeded!
+      if (this.capturedAuthCode) {
+        console.log(
+          `✅ Auth code already captured via CDP, authentication succeeded despite page title showing "${postSubmitTitle}"`,
+        );
+        // Skip the retry logic - we already have what we need
+      } else if (postSubmitTitle.toLowerCase().includes("sign in")) {
         console.log(
           `⚠️ Still on sign-in page after credential submission: "${postSubmitTitle}". This suggests credentials weren't accepted properly.`,
         );


### PR DESCRIPTION
## Problem

Authentication was failing with `net::ERR_ABORTED; maybe frame was detached?` errors even though the auth was actually succeeding.

## Root Cause

Race condition between CDP auth code capture and page title check:

1. **Auth succeeds** - CDP listener captures the `msauth` redirect with authorization code
2. **Page title check runs** - Code checks if `page.title()` still contains "sign in"
3. **False negative** - Title check concludes credentials weren't accepted
4. **Retry fails** - `page.reload()` throws `net::ERR_ABORTED` because the frame was already detached by the successful redirect

## Solution

Added a check for `this.capturedAuthCode` before the page title check. If the auth code was already captured via CDP, skip the retry logic since authentication has already succeeded.

## Testing

- All 155 unit tests pass
- Build succeeds
- Logic verified: downstream code (MFA handling, `waitForAuthCode`) works correctly with the auth code already captured