### PR TITLE
refactor: replace uuid package with built-in crypto.randomUUID()

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,6 @@
     "patchright": "^1.59.4",
     "totp-generator": "^2.0.1",
     "tough-cookie": "^5.1.2",
-    "uuid": "^11.1.0",
     "xvfb": "^0.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,9 +32,6 @@ importers:
       tough-cookie:
         specifier: ^5.1.2
         version: 5.1.2
-      uuid:
-        specifier: ^11.1.0
-        version: 11.1.0
       xvfb:
         specifier: ^0.4.0
         version: 0.4.0
@@ -2416,10 +2413,6 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
-
-  uuid@11.1.0:
-    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
-    hasBin: true
 
   v8-to-istanbul@9.3.0:
     resolution: {integrity: sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==}
@@ -5022,8 +5015,6 @@ snapshots:
       picocolors: 1.1.1
 
   util-deprecate@1.0.2: {}
-
-  uuid@11.1.0: {}
 
   v8-to-istanbul@9.3.0:
     dependencies:

--- a/scripts/request-service-cli.mjs
+++ b/scripts/request-service-cli.mjs
@@ -2,7 +2,7 @@ import "dotenv/config";
 import readline from "node:readline/promises";
 import { stdin as input, stdout as output } from "node:process";
 import OnStar from "../dist/index.mjs";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { execSync } from "node:child_process";
@@ -231,7 +231,7 @@ async function main() {
           opts = { noMetricsRefresh, clientRequestId, clientVersion, os };
         }
 
-        const clientRequestId = opts?.clientRequestId || uuidv4();
+        const clientRequestId = opts?.clientRequestId || randomUUID();
         const noMetricsRefresh =
           typeof opts?.noMetricsRefresh === "boolean"
             ? opts.noMetricsRefresh
@@ -283,7 +283,7 @@ async function main() {
           opts = { noMetricsRefresh, clientRequestId, clientVersion, os };
         }
         const finalOpts = Object.assign({}, opts || {}, {
-          clientRequestId: opts?.clientRequestId || uuidv4(),
+          clientRequestId: opts?.clientRequestId || randomUUID(),
         });
         return client.stopCharging(finalOpts);
       },

--- a/src/RequestService.ts
+++ b/src/RequestService.ts
@@ -23,7 +23,7 @@ import {
 } from "./types";
 import onStarAppConfig from "./onStarAppConfig.json";
 import axios from "axios";
-import { v4 as uuidv4 } from "uuid";
+import { randomUUID } from "crypto";
 import { getGMAPIJWT } from "./auth/GMAuth";
 
 enum OnStarApiCommand {
@@ -309,7 +309,7 @@ class RequestService {
       tcl: String(Math.round(tcl)),
       vehicleId,
       noMetricsRefresh: String(opts?.noMetricsRefresh ?? false),
-      clientRequestId: opts?.clientRequestId ?? uuidv4(),
+      clientRequestId: opts?.clientRequestId ?? randomUUID(),
     });
 
     // VehicleId is derived exclusively from initSession metrics
@@ -377,7 +377,7 @@ class RequestService {
     const bodyParams = new URLSearchParams({
       vehicleId,
       noMetricsRefresh: String(opts?.noMetricsRefresh ?? false),
-      clientRequestId: opts?.clientRequestId ?? uuidv4(),
+      clientRequestId: opts?.clientRequestId ?? randomUUID(),
     });
 
     const makeReq = (token: string) =>

--- a/src/auth/GMAuth.ts
+++ b/src/auth/GMAuth.ts
@@ -7,7 +7,7 @@ import { custom } from "openid-client";
 import fs from "fs";
 import { TOTP } from "totp-generator";
 import https from "https";
-//import { stringify } from "uuid";
+
 import path from "path";
 import jwt from "jsonwebtoken";
 import { chromium, Browser, BrowserContext, Page } from "patchright";


### PR DESCRIPTION
## Summary

Replaces the `uuid` npm package with Node.js built-in `crypto.randomUUID()`, eliminating a runtime dependency.

## Motivation

- **uuid v14 dropped CommonJS support** — since our Rollup config marks dependencies as external, the CJS bundle (`dist/index.cjs`) would emit `require('uuid')` which fails with ESM-only uuid v14+
- **`crypto.randomUUID()` is functionally identical** — produces RFC 4122 v4 UUIDs, available since Node.js 14.17+
- **Removes dependency churn** — uuid has had breaking changes in v9, v10, v11, and v14; a platform API doesn't break
- **Scripts already use it** — `setup-env.js` and `credential-manager.js` already use `crypto.randomUUID()`

## Changes

| File | Change |
|------|--------|
| `src/RequestService.ts` | `uuid` → `import { randomUUID } from "crypto"` |
| `scripts/request-service-cli.mjs` | `uuid` → `import { randomUUID } from "node:crypto"` |
| `src/auth/GMAuth.ts` | Removed commented-out `//import { stringify } from "uuid"` (dead code) |
| `package.json` | Removed `uuid` from dependencies |

## Verification

- [x] `pnpm build` — both CJS and ESM bundles build successfully
- [x] `pnpm test` — 191 unit + 3 functional tests pass (6 skipped)
- [x] CJS bundle loads correctly via `require()`
- [x] Output format verified identical (10,000 samples, RFC 4122 v4 pattern)
- [x] Compatible with Node.js 18+ (Node-RED v4 minimum)