### PR TITLE
fix(build): add esmExternals to Rollup for tough-cookie v6 ESM compatibility

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default {
   plugins: [
     json(),
     resolve(),
-    commonJS(),
+    commonJS({ esmExternals: true }),
     typescript({
       tsconfig: "./tsconfig.json",
       declarationDir: "dist", // Added for compatibility with @rollup/plugin-typescript 12.1.1


### PR DESCRIPTION
## Problem

After merging the tough-cookie v5→v6 upgrade (#653), the ESM bundle (`dist/index.mjs`) fails at runtime:

```
import require$$0, { CookieJar } from 'tough-cookie';
       ^^^^^^^^^^
SyntaxError: The requested module 'tough-cookie' does not provide an export named 'default'
```

## Root Cause

tough-cookie v6 switched from CJS to ESM (`"type": "module"`). The `@rollup/plugin-commonjs` was generating a synthetic default import (`require$$0`) for tough-cookie in the ESM output, but tough-cookie v6 no longer provides a default export.

## Fix

Added `esmExternals: true` to the `commonJS()` plugin config. This tells the plugin that external dependencies may be ESM and should not get CJS default-export interop treatment.

## Verified

- ✅ `pnpm build` succeeds
- ✅ ESM bundle: `import * as toughCookie from 'tough-cookie'` (no more `require$$0`)
- ✅ CJS bundle: `require('tough-cookie')` (unchanged, works via tough-cookie's CJS entry)
- ✅ `require('./dist/index.cjs')` — loads successfully
- ✅ `import('./dist/index.mjs')` — loads successfully
- ✅ `pnpm test` — 200/200 tests pass (197 unit + 3 functional)
- ✅ `pnpm run:request-service` — full auth + API call works
- ✅ Full browser re-auth flow with cookie sync verified