### PR TITLE
fix: add transformIgnorePatterns for ESM dependencies in Jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,4 +5,5 @@ export default {
   coveragePathIgnorePatterns: [
     "./src/auth/GMAuth.ts", // Add the path to the file you want to exclude
   ],
+  transformIgnorePatterns: ["node_modules/(?!(agent-base|http-cookie-agent)/)"],
 };


### PR DESCRIPTION
## Problem

`http-cookie-agent@7.0.4` updated its dependency `agent-base` to v9, which ships ESM-only (`"type": "module"`). Jest's default config skips transforming `node_modules`, causing:

```
SyntaxError: Cannot use import statement outside a module
```

This blocks PR #710 and PR #715.

## Fix

Add `transformIgnorePatterns` to `jest.config.js` to exclude `agent-base` and `http-cookie-agent` from the ignore list, so Jest transpiles them during tests.

## Testing

All unit tests pass locally (191 passed, 6 skipped).