### PR TITLE
fix: simplify transformIgnorePatterns for pnpm compatibility

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,6 @@ export default {
     "./src/auth/GMAuth.ts", // Add the path to the file you want to exclude
   ],
   transformIgnorePatterns: [
-    "node_modules/(?!(\\.pnpm/(agent-base|http-cookie-agent)|agent-base|http-cookie-agent)/)",
+    "node_modules/(?!\\.pnpm|agent-base|http-cookie-agent)",
   ],
 };


### PR DESCRIPTION
## Problem

Follow-up to PRs #721 and #722. The previous `transformIgnorePatterns` regex failed to match pnpm's nested path structure because pnpm includes version suffixes (e.g. `agent-base@9.0.0`) in directory names.

Failing path from CI:
```
node_modules/.pnpm/agent-base@9.0.0/node_modules/agent-base/dist/index.js
```

## Fix


## Verification

Tested against all exact paths from CI logs:
```
TRANSFORMED  node_modules/.pnpm/agent-base@9.0.0/node_modules/agent-base/dist/index.js
TRANSFORMED  node_modules/.pnpm/http-cookie-agent@7.0.4_tough-cookie@6.0.1/node_modules/http-cookie-agent/...
TRANSFORMED  node_modules/agent-base/dist/index.js
IGNORED      node_modules/lodash/lodash.js
IGNORED      node_modules/.pnpm/lodash@4.18.1/node_modules/lodash/lodash.js
IGNORED      node_modules/axios/index.js
IGNORED      node_modules/.pnpm/axios@1.16.0/node_modules/axios/index.js
```

All unit tests pass (191 passed, 6 skipped).