### PR TITLE
fix: add JS transform for ESM node_modules dependencies

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,6 +5,16 @@ export default {
   coveragePathIgnorePatterns: [
     "./src/auth/GMAuth.ts", // Add the path to the file you want to exclude
   ],
+  transform: {
+    "^.+\\.[tj]sx?$": [
+      "ts-jest",
+      {
+        tsconfig: {
+          allowJs: true,
+        },
+      },
+    ],
+  },
   transformIgnorePatterns: [
     "node_modules/(?!\\.pnpm|agent-base|http-cookie-agent)",
   ],


### PR DESCRIPTION
Follow-up to PRs #721, #722, #723. The previous fixes correctly configured `transformIgnorePatterns` but tests still failed because the `transform` config (from ts-jest preset) only matched `.ts`/`.tsx` files. ESM `.js` files from `agent-base@9` had no transformer and Jest could not parse them.

This adds `ts-jest` with `allowJs: true` to handle both `.ts` and `.js` files.

Verified locally with `http-cookie-agent@7.0.4` + `agent-base@9.0.0` installed — 191 tests pass.