### PR TITLE
fix(ci): fix publish workflow for pnpm v11

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,16 +22,16 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: https://registry.npmjs.org/
           cache: "pnpm"
-      - name: Update npm for trusted publishing
-        run: npm install -g npm@latest
       - name: Install dependencies
         run: pnpm install
 
+      - name: Build
+        run: pnpm run build
+
       - name: Publish package
-        run: pnpm publish --access public --no-git-checks
+        run: npm publish --access public --provenance
         env:
-          #NODE_AUTH_TOKEN: ${{secrets.NODE_AUTH_TOKEN}}
           NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
## Problem

The v2.16.4 publish workflow failed because `npm install -g npm@latest` crashes with `Cannot find module 'promise-retry'` when pnpm v11's `PNPM_HOME` is on the PATH, corrupting npm's module resolution.

## Fix

- **Remove** the broken `npm install -g npm@latest` step
- **Switch Node 22 → 24** — Node 24 ships npm >= 11.5.1 which natively supports OIDC trusted publishing (no npm upgrade needed)
- **Use `npm publish`** instead of `pnpm publish` for OIDC/provenance support
- **Add explicit `pnpm run build` step** since `npm publish` lifecycle behavior differs from `pnpm publish`

## After merge

Re-create the v2.16.4 tag on the new HEAD to trigger the publish workflow.