### PR TITLE
Strip UTF-8 BOM before parsing cached token files

### DIFF
--- a/src/auth/GMAuth.ts
+++ b/src/auth/GMAuth.ts
@@ -15,6 +15,15 @@ import { randomInt } from "crypto";
 import { execSync } from "child_process";
 import * as net from "net";
 
+// Strips a leading UTF-8 BOM before parsing, so cached token files that pick
+// one up (e.g. from being copied/restored via Windows tooling) still load
+// instead of failing JSON.parse and forcing an unnecessary full re-login.
+function readJSONFile<T>(filePath: string): T {
+  const raw = fs.readFileSync(filePath, "utf-8");
+  const content = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
+  return JSON.parse(content) as T;
+}
+
 // Define an interface for the vehicle structure and the payload containing them
 interface Vehicle {
   vin: string;
@@ -2779,9 +2788,7 @@ export class GMAuth {
 
     if (fs.existsSync(tokenFilePath)) {
       try {
-        const storedToken = JSON.parse(
-          fs.readFileSync(tokenFilePath, "utf-8"),
-        ) as GMAPITokenResponse;
+        const storedToken = readJSONFile<GMAPITokenResponse>(tokenFilePath);
 
         // Decode the JWT payload
         const decodedPayload = jwt.decode(storedToken.access_token);
@@ -3397,9 +3404,7 @@ export class GMAuth {
     if (fs.existsSync(this.MSTokenPath)) {
       let storedTokens = null;
       try {
-        storedTokens = JSON.parse(
-          fs.readFileSync(this.MSTokenPath, "utf-8"),
-        ) as TokenSet;
+        storedTokens = readJSONFile<TokenSet>(this.MSTokenPath);
       } catch (err) {
         console.log("Stored MS token was not parseable, getting new token");
         return false;

--- a/src/auth/GMAuth.ts
+++ b/src/auth/GMAuth.ts
@@ -18,7 +18,8 @@ import * as net from "net";
 // Strips a leading UTF-8 BOM before parsing, so cached token files that pick
 // one up (e.g. from being copied/restored via Windows tooling) still load
 // instead of failing JSON.parse and forcing an unnecessary full re-login.
-function readJSONFile<T>(filePath: string): T {
+// exported for unit testing
+export function readJSONFile<T>(filePath: string): T {
   const raw = fs.readFileSync(filePath, "utf-8");
   const content = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw;
   return JSON.parse(content) as T;

--- a/test/unit/readJSONFile.test.ts
+++ b/test/unit/readJSONFile.test.ts
@@ -1,0 +1,25 @@
+import { readJSONFile } from "../../src/auth/GMAuth";
+import fs from "fs";
+
+jest.mock("fs");
+const mockReadFileSync = fs.readFileSync as jest.Mock;
+
+describe("readJSONFile", () => {
+  const payload = { access_token: "abc", token_type: "bearer" };
+  const json = JSON.stringify(payload);
+
+  test("parses normal JSON", () => {
+    mockReadFileSync.mockReturnValue(json);
+    expect(readJSONFile("/fake/path.json")).toEqual(payload);
+  });
+
+  test("strips UTF-8 BOM before parsing", () => {
+    mockReadFileSync.mockReturnValue("\uFEFF" + json);
+    expect(readJSONFile("/fake/path.json")).toEqual(payload);
+  });
+
+  test("throws on malformed JSON", () => {
+    mockReadFileSync.mockReturnValue("{bad json}");
+    expect(() => readJSONFile("/fake/path.json")).toThrow();
+  });
+});


### PR DESCRIPTION
## Problem

`loadCurrentGMAPIToken()` and `loadMSToken()` both `JSON.parse` the cached `gm_tokens.json` / `microsoft_tokens.json` files directly, with no tolerance for a leading UTF-8 BOM.

A BOM-prefixed file (common when these files are copied or restored via Windows tooling - e.g. moving a token cache to a new host, or restoring from certain backup tools) fails `JSON.parse` silently and is logged as "not parseable, getting new token" - forcing an unnecessary full interactive browser re-login instead of reusing valid cached credentials.

Reproduced this directly while migrating an onstar2mqtt instance to a new host: copied both token files over, and got a fresh Playwright/Xvfb browser login instead of the expected silent token reuse, purely because the file-copy step (PowerShell's `Out-File -Encoding utf8`) added a BOM.

## Fix

Small shared `readJSONFile()` helper that strips a leading BOM before parsing, used at both call sites. No behavior change for files that don't have a BOM (the vast majority, since the app's own `fs.writeFileSync` calls never add one - this only affects externally-copied/restored files).

## Testing

- `pnpm run build` - clean, no type errors
- `pnpm run test:unit` - 191 passed, 6 skipped (pre-existing skips), 0 failed
- `pnpm run test:auth` - fails locally as expected (requires live GM credentials via env vars), unrelated to this change